### PR TITLE
Bugfix: Change component naming convention

### DIFF
--- a/src/pages/equipment/NewEquipment.jsx
+++ b/src/pages/equipment/NewEquipment.jsx
@@ -3,7 +3,7 @@ import { useNavigate } from "react-router-dom"
 import { EquipmentForm } from "../../components/forms/EquipmentForm"
 import { createEquipment, createLabEquipment } from "../../data/equipment"
 
-export const NewEquipmentForm = () => {
+export const NewEquipment = () => {
   const formEl = useRef()
   const navigate = useNavigate()
 

--- a/src/views/ApplicationViews.jsx
+++ b/src/views/ApplicationViews.jsx
@@ -1,6 +1,6 @@
 import { Outlet, Route, Routes } from "react-router-dom"
 import { NavBar } from "../components/nav/NavBar"
-import { NewEquipmentForm } from "../pages/equipment/NewEquipmentForm"
+import { NewEquipment } from "../pages/equipment/NewEquipment"
 
 export const ApplicationViews = () => {
   return (
@@ -14,7 +14,7 @@ export const ApplicationViews = () => {
           </>
         }
       >
-        <Route path="new-equipment" element={<NewEquipmentForm />} />
+        <Route path="new-equipment" element={<NewEquipment />} />
       </Route>
     </Routes>
   )


### PR DESCRIPTION
shortened NewEquipmentForm to NewEquipment. Future pages that have a form will not have "Form" in the component name