### PR TITLE
Include token in HTTP request options

### DIFF
--- a/src/data/authentication.jsx
+++ b/src/data/authentication.jsx
@@ -1,5 +1,11 @@
-import { fetchWithResponse, postOptions } from "./fetcher"
+import { fetchWithResponse } from "./fetcher"
 
 export const login = async (user) => {
-  return await fetchWithResponse("login", postOptions(user))
+  return await fetchWithResponse("login", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(user),
+  })
 }

--- a/src/data/fetcher.jsx
+++ b/src/data/fetcher.jsx
@@ -1,4 +1,5 @@
 const apiURL = "http://localhost:8000"
+const userToken = JSON.parse(localStorage.getItem("fairy_auth")).token
 
 const checkError = (res) => {
   if (!res.ok) {
@@ -28,7 +29,7 @@ export const getOptions = () => {
   return {
     method: "GET",
     headers: {
-      Authorization: "Token 91dddf9bcff7eb81f18d40622baa0dede6c22278",
+      Authorization: `Token ${userToken}`,
     },
   }
 }
@@ -38,7 +39,7 @@ export const postOptions = (dataObject) => {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      Authorization: "Token 91dddf9bcff7eb81f18d40622baa0dede6c22278",
+      Authorization: `Token ${userToken}`,
     },
     body: JSON.stringify(dataObject),
   }


### PR DESCRIPTION
## Changes 
* removed usage of postOptions() in login because this function does not need access to a token
* get userToken from localStorage in fetcher, and add userToken to postOptions and getOptions